### PR TITLE
has_key is not available on python 3.x

### DIFF
--- a/calendarific/__init__.py
+++ b/calendarific/__init__.py
@@ -10,7 +10,7 @@ class v2:
     def holidays(self, parameters):
         url = 'https://calendarific.com/api/v2/holidays?'
 
-        if parameters.has_key('api_key') is False:
+        if 'api_key' not in parameters:
             parameters['api_key'] = self.api_key
 
         response = requests.get(url, params=parameters);

--- a/calendarific/__init__.py
+++ b/calendarific/__init__.py
@@ -17,7 +17,7 @@ class v2:
         data     = json.loads(response.text)
 
         if response.status_code != 200:
-            if data.has_key('error') is False:
+            if 'error' not in data:
                 data['error'] = 'Unknown error.'
 
         return data


### PR DESCRIPTION
+ The package breaks on Python 3.x
+ On python 3.x you are treated with error

```
'dict' object has no attribute 'has_key'
```

+ This simple fix helps to overcome this problem
+ Issue: https://github.com/calendarific/python-calendarific/issues/1